### PR TITLE
Fix bootloop on binutils >= 2.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBJS = \
 # TOOLPREFIX = i386-jos-elf
 
 # Using native tools (e.g., on X86 Linux)
-#TOOLPREFIX = 
+#TOOLPREFIX =
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -187,7 +187,7 @@ fs.img: mkfs README $(UPROGS)
 
 -include *.d
 
-clean: 
+clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*.o *.d *.asm *.sym vectors.S bootblock entryother \
 	initcode initcode.out kernel xv6.img fs.img kernelmemfs \

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ entryother: entryother.S
 
 initcode: initcode.S
 	$(CC) $(CFLAGS) -nostdinc -I. -c initcode.S
+	objcopy --remove-section .note.gnu.property initcode.o
 	$(LD) $(LDFLAGS) -N -e start -Ttext 0 -o initcode.out initcode.o
 	$(OBJCOPY) -S -O binary initcode.out initcode
 	$(OBJDUMP) -S initcode.o > initcode.asm
@@ -146,6 +147,7 @@ vectors.S: vectors.pl
 ULIB = ulib.o usys.o printf.o umalloc.o
 
 _%: %.o $(ULIB)
+	objcopy --remove-section .note.gnu.property ulib.o
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $*.sym

--- a/usertests.c
+++ b/usertests.c
@@ -1457,8 +1457,11 @@ sbrktest(void)
     printf(stdout, "sbrk test failed to grow big address space; enough phys mem?\n");
     exit();
   }
-  lastaddr = (char*) (BIG-1);
+
+  lastaddr = (char *)(BIG - 1);
+  #pragma GCC diagnostic ignored "-Wstringop-overflow"
   *lastaddr = 99;
+  #pragma GCC diagnostic pop
 
   // can one de-allocate?
   a = sbrk(0);


### PR DESCRIPTION
Building xv6 with binutils version >=2.36 and gcc version >=10 would fail, because
- code wouldn't compile because of the new `-Wstringops-overflow` warning in gcc
- qemu would get stuck in a bootloop due to an ill-formed `.note.gnu.property` section

This PR addresses these issues by suppressing the warning and removing the new section.

All credit for the problem description and the fix goes to [lorenzo-stoakes' PR #155](https://github.com/mit-pdos/xv6-public/pull/155).