### PR TITLE
Fixes for GCC>=12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror -fno-omit-frame-pointer
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
+CFLAGS += -I. -mgeneral-regs-only
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null | head -n 1)

--- a/mp.c
+++ b/mp.c
@@ -69,6 +69,10 @@ mpsearch(void)
 // Check for correct signature, calculate the checksum and,
 // if correct, check the version.
 // To do: check extended table checksum.
+#if __GNUC__ >= 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 static struct mpconf*
 mpconfig(struct mp **pmp)
 {
@@ -137,3 +141,6 @@ mpinit(void)
     outb(0x23, inb(0x23) | 1);  // Mask external interrupts.
   }
 }
+#if __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif

--- a/sh.c
+++ b/sh.c
@@ -53,7 +53,11 @@ int fork1(void);  // Fork but panics on failure.
 void panic(char*);
 struct cmd *parsecmd(char*);
 
-// Execute cmd.  Never returns.
+// Execute cmd. Never returns.
+#if __GNUC__ >= 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
+#endif
 void
 runcmd(struct cmd *cmd)
 {
@@ -129,6 +133,9 @@ runcmd(struct cmd *cmd)
   }
   exit();
 }
+#if __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif
 
 int
 getcmd(char *buf, int nbuf)


### PR DESCRIPTION
## Issue
With the update of GCC to version `12`, at least 3 new issues have been introduced regarding the compilation and launch of `xv6` in QEMU. 

## Fixes
The fixes include:
1. Infinite recursion error in the `sh.c/runcmd` function because it never returns.  See bea5c28
2. Array subscript error when accessing fields of the `conf` structure in the `mp.c` file. This is probably a _false positive_ one. See a1dda23
3. Bootloop when loading `xv6` in QEMU. This was caused by the fact that xv6 does not track the state of XMM registers. Therefore, SIMD extensions should be disabled. See 861f653

> **Note**
>
> Commit 861f653 comes from [this pull request](https://github.com/AnubisLMS/xv6/pull/9). However, the `-mno-sse` flag, which disables Streaming SIMD Extensions, has been [replaced](https://github.com/AnubisLMS/xv6/commit/43b01f862bdf9a77039ed6870b71186333107509) by `-mgeneral-regs-only`, which forces the compiler to generate code that uses only the general-purpose registers and will work on future versions without additional flags for disabling specific SIMD extensions.

## Tests
Tested on Ubuntu 22.04 LTS (GCC `11.4.0`, QEMU `6.2.0`)

Also tested on:
* GCC `10.5.0`, `11.4.0`, `12.3.0`, `13.2.1`
* QEMU `8.0.4`, `8.1.0`